### PR TITLE
Hide example/template on jobs page

### DIFF
--- a/jobs.md
+++ b/jobs.md
@@ -12,13 +12,14 @@ feature: beers.png
 
 This is the devbeers job board. Have a job opening in your company? Make a [pull request here](https://github.com/devbeers/devbeers.github.io/blob/master/jobs.md).
 
+<!-- Job template
 ### [Company](http://example.org/link-to-company)
 
 - Position: Software Developer
 - Skills:	Node.js / Ruby / MongoDB
 - Description: Awesome position at 'company', looking for a developer with X years of experience, to work on a project X, Y, Z. Contact us via xyx@company.com
 - Link: [http://example.org/amazing-job](http://example.org/amazing-job)
-
+-->
  
 ### [ChefsClub](https://www.chefsclub.com.br/)
 


### PR DESCRIPTION
There's no need to show the example job on website page, so I've commented it out.

The example can still be ~~copied~~ used as template.

![screenshot from 2016-05-11 14-45-32](https://cloud.githubusercontent.com/assets/1295197/15190602/2e386a9e-1787-11e6-8a4b-300d052fab8f.png)
